### PR TITLE
Update host with correct ip address

### DIFF
--- a/DuinoCoin_Esp_Async_Master/DuinoCoin_Pool.ino
+++ b/DuinoCoin_Esp_Async_Master/DuinoCoin_Pool.ino
@@ -27,7 +27,7 @@ void UpdateHostPort(String input)
   int port = doc["port"];
 
   Serial.println("[ ]Update " + String(name) + " " + String(ip) + " " + String(port));
-  SetHostPort(String(host), port);
+  SetHostPort(String(ip), port);
 }
 
 void UpdatePool()


### PR DESCRIPTION
The UpdateHostPort function would never connect to the correct pool, because the host variable was always 149.91.88.18 with the pools port. This is why many people could not connect to a Pool. After resetting until there is a pool with the same port (6000) it was possible to connect. That is why in the UpdateHostPort function the variable host has to be changed to ip. Then its working fine.

Related to issue #37 and #38