### PR TITLE
Update JOB variable

### DIFF
--- a/DuinoCoin_Esp_Async_Master/DuinoCoin_Esp_Async_Master.ino
+++ b/DuinoCoin_Esp_Async_Master/DuinoCoin_Esp_Async_Master.ino
@@ -44,7 +44,7 @@ const char* rigIdentifier = "AVR-I2C";  // Change this if you want a custom mine
 #if ESP32
 #define LED_BUILTIN 2
 #define MINER "AVR I2C v2.7.3"
-#define JOB "AVR"
+#define JOB "AVR,"
 #endif
 
 void handleSystemEvents(void) {


### PR DESCRIPTION
Miners didn't get recognized because of the typo in the JOB variable for ESP8266 boards